### PR TITLE
Remove spaces from image URL

### DIFF
--- a/get_listings/get_listings.py
+++ b/get_listings/get_listings.py
@@ -42,6 +42,8 @@ def get_listings(search_term):
         for item in response["searchResults"]["items"]:
             # imageURL returns with a mix of forward and backward slashes. Make them all forward.
             image_url = item["imageURL"].replace('\\', '/')
+            # imageURL returns with a space sometimes. Remove spaces.
+            image_url = image_url.replace(' ', '')
             # sometimes endTime has trailing fractions of a second, e.g. "0.75"
             end_time = re.sub(r"\.\d*$", '', item["endTime"])
             # convert time format with "T" separator

--- a/get_listings/remove_spaces_from_image_url.py
+++ b/get_listings/remove_spaces_from_image_url.py
@@ -1,0 +1,16 @@
+import re
+import firebase_admin
+from firebase_admin import firestore
+
+app = firebase_admin.initialize_app()
+db = firestore.client()
+
+docs = db.collection('listings').stream()
+
+for doc in docs:
+    listing = doc.to_dict()
+    if bool(re.search(' ', listing['image_url'])):
+        print(listing)
+        listing['image_url'] = listing['image_url'].replace(' ', '')
+        listings_doc_ref = db.collection('listings').document(str(listing["item_id"]))
+        listings_doc_ref.set(listing, merge=True)


### PR DESCRIPTION
The shopgoodwill API sometimes returns image URLs with spaces. This is busted, remove the spaces.